### PR TITLE
Better GoTo options for click events and groupdetections

### DIFF
--- a/src/PamModel/PamModel.java
+++ b/src/PamModel/PamModel.java
@@ -451,7 +451,7 @@ final public class PamModel implements PamModelInterface, PamSettings {
 		mi = PamModuleInfo.registerControlledUnit(EffortControl.class.getName(), EffortControl.unitType);
 		mi.setToolTipText("Record observer monitoring effort");
 		mi.setModulesMenuGroup(utilitiesGroup);
-		mi.setHidden(SMRUEnable.isEnable() == false);
+//		mi.setHidden(SMRUEnable.isEnable() == false);
 		mi.setToolTipText("Enables an observer to enter their name and infomation about which displays are being monitored");
 		mi.setMaxNumber(1);
 

--- a/src/clickDetector/ClickBTDisplay.java
+++ b/src/clickDetector/ClickBTDisplay.java
@@ -3660,15 +3660,15 @@ public class ClickBTDisplay extends ClickDisplay implements PamObserver, PamSett
 	/**
 	 * Scroll the display to a specific event. 
 	 * @param event event to scroll to
+	 * @param beforeTime seconds before the event to scroll to. 
 	 */
-	public void gotoEvent(OfflineEventDataUnit event) {
-		long evStart = event.getTimeMilliseconds();
+	public void gotoEvent(OfflineEventDataUnit event, int beforeTime) {
+		long evStart = event.getTimeMilliseconds() - beforeTime*1000;
 		if (evStart < hScrollBar.getMinimumMillis() || evStart > hScrollBar.getMaximumMillis()) {
 			long range = hScrollBar.getMaximumMillis() - hScrollBar.getMinimumMillis();
 			hScrollBar.setRangeMillis(evStart, evStart + range, true);
 		}
 		hScrollBar.setValueMillis(evStart);
-
 	}
 
 	int playbackStatus = PlaybackProgressMonitor.PLAY_END;

--- a/src/clickDetector/ClickControl.java
+++ b/src/clickDetector/ClickControl.java
@@ -1015,9 +1015,10 @@ public class ClickControl extends PamControlledUnit implements PamSettings {
 	/**
 	 * Scrolls the display to a specific event. 
 	 * @param event event to scroll to
+	 * @param beforeTime 
 	 */
-	public void gotoEvent(OfflineEventDataUnit event) {
-		tabPanelControl.clickDisplayManager.gotoEvent(event);
+	public void gotoEvent(OfflineEventDataUnit event, int beforeTime) {
+		tabPanelControl.clickDisplayManager.gotoEvent(event, beforeTime);
 	}
 
 	/**

--- a/src/clickDetector/ClickDisplayManager.java
+++ b/src/clickDetector/ClickDisplayManager.java
@@ -463,11 +463,12 @@ public class ClickDisplayManager implements PamSettings {
 	/**
 	 * Scroll the time displays to a specific event. 
 	 * @param event
+	 * @param beforeTime 
 	 */
-	public void gotoEvent(OfflineEventDataUnit event) {
+	public void gotoEvent(OfflineEventDataUnit event, int beforeTime) {
 		for (int i = 0; i < windowList.size(); i++) {
 			if (windowList.get(i).getClass() == ClickBTDisplay.class) {
-				((ClickBTDisplay)windowList.get(i)).gotoEvent(event);
+				((ClickBTDisplay)windowList.get(i)).gotoEvent(event, beforeTime);
 			}
 		}
 	}

--- a/src/clickDetector/offlineFuncs/EventListDialog.java
+++ b/src/clickDetector/offlineFuncs/EventListDialog.java
@@ -175,9 +175,19 @@ public class EventListDialog extends PamDialog {
 		JPopupMenu menu = new JPopupMenu();
 		JMenuItem menuItem;
 		int evNo = event.getDatabaseIndex();
-		menuItem = new JMenuItem(String.format("Goto event %d ...", evNo));
-		menuItem.addActionListener(new GotoEvent(event));
-		menu.add(menuItem);
+		int[] beforeTimes = {0, 10, 60};
+		for (int i = 0; i < beforeTimes.length; i++) {
+			String title;
+			if (beforeTimes[i] == 0) {
+				title = String.format("Goto event %d ...", evNo);
+			}
+			else {
+				title = String.format("Goto %ds before event %d ...", beforeTimes[i], evNo);
+			}
+			menuItem = new JMenuItem(title);
+			menuItem.addActionListener(new GotoEvent(event, beforeTimes[i]));
+			menu.add(menuItem);
+		}
 		menuItem = new JMenuItem(String.format("Edit event %d ...", evNo));
 		menuItem.addActionListener(new EditEvent(event));
 		menu.add(menuItem);
@@ -219,14 +229,16 @@ public class EventListDialog extends PamDialog {
 	private class GotoEvent implements ActionListener {
 		
 		private OfflineEventDataUnit event;
+		private int beforeTime;
 
-		public GotoEvent(OfflineEventDataUnit event) {
+		public GotoEvent(OfflineEventDataUnit event, int beforeTime) {
 			this.event = event;
+			this.beforeTime = beforeTime;
 		}
 
 		@Override
 		public void actionPerformed(ActionEvent arg0) {
-			clickControl.gotoEvent(event);
+			clickControl.gotoEvent(event, beforeTime);
 		}
 		
 	}

--- a/src/detectiongrouplocaliser/DetectionGroupControl.java
+++ b/src/detectiongrouplocaliser/DetectionGroupControl.java
@@ -24,7 +24,8 @@ import detectiongrouplocaliser.dialogs.DisplayOptionsHandler;
 import userDisplay.UserDisplayControl;
 
 /**
- * Class for grouping any type of data together. 
+ * Class for grouping any type of data together. Not really a localiser, but 
+ * does include some localisation options.<br> 
  * Will attempt to offer a variety of localisation options and will store data for each group
  * in a pair of database tables. 
  * @author dg50

--- a/src/detectiongrouplocaliser/dialogs/DetectionGroupTable.java
+++ b/src/detectiongrouplocaliser/dialogs/DetectionGroupTable.java
@@ -56,23 +56,23 @@ import warnings.PamWarning;
 public class DetectionGroupTable extends UserDisplayComponentAdapter implements DetectionGroupObserver {
 
 	private JPanel mainPanel;
-	
+
 	private DetectionGroupProcess detectionGroupProcess;
-	
+
 	private DetectionGroupDataBlock detectionGroupDataBlock;
-	
+
 	private DetectionGroupControl detectionGroupControl;
-	
+
 	private JTable table;
 
 	private TableModel tableModel;
 
 	private JScrollPane scrollPane;
-	
+
 	private JPanel controlPanel;
-	
+
 	private JRadioButton showAll, showCurrent;
-	
+
 	private JButton checkIntegrity;
 
 	private boolean isViewer;
@@ -80,7 +80,7 @@ public class DetectionGroupTable extends UserDisplayComponentAdapter implements 
 	private DisplayOptionsHandler displayOptionsHandler;
 
 	private SwingTableColumnWidths widthManager;
-	
+
 	public DetectionGroupTable(DetectionGroupProcess detectionGroupProcess) {
 		super();
 		this.detectionGroupProcess = detectionGroupProcess;
@@ -95,7 +95,7 @@ public class DetectionGroupTable extends UserDisplayComponentAdapter implements 
 		mainPanel.add(BorderLayout.CENTER, scrollPane);
 		detectionGroupControl.addGroupObserver(this);
 		table.addMouseListener(new TableMouseHandler());
-		
+
 		if (isViewer) {
 			displayOptionsHandler = detectionGroupControl.getDisplayOptionsHandler();
 			controlPanel = new JPanel(new BorderLayout());
@@ -134,9 +134,9 @@ public class DetectionGroupTable extends UserDisplayComponentAdapter implements 
 				}
 			});
 		}
-		
-		
-//		sortColumnWidths();
+
+
+		//		sortColumnWidths();
 	}
 
 
@@ -144,7 +144,7 @@ public class DetectionGroupTable extends UserDisplayComponentAdapter implements 
 	public Component getComponent() {
 		return mainPanel;
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see userDisplay.UserDisplayComponentAdapter#openComponent()
 	 */
@@ -195,7 +195,7 @@ public class DetectionGroupTable extends UserDisplayComponentAdapter implements 
 				showPopupMenu(e);
 			}
 		}
-		
+
 	}
 
 	@Override
@@ -205,7 +205,7 @@ public class DetectionGroupTable extends UserDisplayComponentAdapter implements 
 
 	public void editSelectedEvent(MouseEvent e) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 
@@ -234,26 +234,39 @@ public class DetectionGroupTable extends UserDisplayComponentAdapter implements 
 		menuItem = annotationHandler.createAnnotationEditMenu(dgdu);
 		menuItem.setIcon(menuIcon);
 		pMenu.add(menuItem);
-		
-		menuItem = new JMenuItem("Scroll to Group UID " + dgdu.getUID() + " at " + PamCalendar.formatDBDateTime(dgdu.getTimeMilliseconds()));
-		menuItem.setIcon(menuIcon);
-		menuItem.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				scrollToEvent(dgdu.getTimeMilliseconds());
+
+		int[] beforeTimesSecs = {0, 10, 60};
+		pMenu.addSeparator();
+		for (int i = 0; i < beforeTimesSecs.length; i++) {
+			int before = beforeTimesSecs[i];
+			String title;
+			if (before == 0) {
+				title = "Scroll to Group UID " + dgdu.getUID() + " at " + PamCalendar.formatDBDateTime(dgdu.getTimeMilliseconds());
 			}
-		});
-		pMenu.add(menuItem);
+			else {
+				title = String.format("Scroll to %ds before Group UID %d", before, dgdu.getUID());
+			}
+			menuItem = new JMenuItem(title);
+			//		menuItem.setIcon(menuIcon);
+			menuItem.addActionListener(new ActionListener() {
+				@Override
+				public void actionPerformed(ActionEvent e) {
+					scrollToEvent(dgdu.getTimeMilliseconds()-before*1000);
+				}
+			});
+			pMenu.add(menuItem);
+		}
+
 		pMenu.show(e.getComponent(), e.getX(), e.getY());
 	}
 
 	protected void scrollToEvent(long timeMilliseconds) {
 		// start a it earlier. 
 		timeMilliseconds -= 5000;
-//		now WTF - how do I tell every scroller to go to this point in time ? 
+		//		now WTF - how do I tell every scroller to go to this point in time ? 
 		AbstractScrollManager scrollManager = AbstractScrollManager.getScrollManager();
 		scrollManager.startDataAt(detectionGroupDataBlock, timeMilliseconds);
-		
+
 	}
 
 
@@ -300,9 +313,9 @@ public class DetectionGroupTable extends UserDisplayComponentAdapter implements 
 			TableColumn tableCol = table.getColumnModel().getColumn(i);
 			tableCol.setPreferredWidth(tableModel.getRelativeWidth(i)*50);
 		}
-		
+
 	}
-	
+
 	private int getViewOption() {
 		if (!isViewer) {
 			return DisplayOptionsHandler.SHOW_ALL;
@@ -348,7 +361,7 @@ public class DetectionGroupTable extends UserDisplayComponentAdapter implements 
 
 		@Override
 		public int getRowCount() {
-//			System.out.println("getRowCount()");
+			//			System.out.println("getRowCount()");
 			if (getViewOption() ==  DisplayOptionsHandler.SHOW_ALL) {
 				firstRowToShow = 0;
 				return numRowsToShow = detectionGroupDataBlock.getUnitsCount();
@@ -396,9 +409,9 @@ public class DetectionGroupTable extends UserDisplayComponentAdapter implements 
 						return null;
 					}
 				case 2:
-//					if (iRow == 0) {
-//						System.out.println("getValueAt(0,0)");
-//					}
+					//					if (iRow == 0) {
+					//						System.out.println("getValueAt(0,0)");
+					//					}
 					return dgdu.getUID();
 				case 3:
 					return PamCalendar.formatDateTime(dgdu.getTimeMilliseconds());
@@ -416,16 +429,16 @@ public class DetectionGroupTable extends UserDisplayComponentAdapter implements 
 					if (annotation != null) {
 						return annotation.toString();
 					}
-					
+
 				}
-				
+
 			}
 			catch (Exception e) {
 				return null;
 			}
 			return null;
 		}
-		
+
 		@Override
 		public Class<?> getColumnClass(int col) {
 			if (col == 0) {
@@ -433,7 +446,7 @@ public class DetectionGroupTable extends UserDisplayComponentAdapter implements 
 			}
 			return super.getColumnClass(col);
 		}
-		
+
 		/* (non-Javadoc)
 		 * @see javax.swing.table.AbstractTableModel#fireTableStructureChanged()
 		 */
@@ -486,7 +499,7 @@ public class DetectionGroupTable extends UserDisplayComponentAdapter implements 
 		widthManager = new SwingTableColumnWidths(uniqueName, table);
 		super.setUniqueName(uniqueName);
 	}
-	
-	
-	
+
+
+
 }


### PR DESCRIPTION
In tables, can now scroll to 10 or 60s before the marked event, which is
often more useful than scrolling to the exact start of those events.