### PR TITLE
Fix to issue #80 (#81)

### DIFF
--- a/src/SoundRecorder/RecorderSettings.java
+++ b/src/SoundRecorder/RecorderSettings.java
@@ -64,6 +64,10 @@ public class RecorderSettings implements Serializable, Cloneable, ManagedParamet
 	 */
 	public String outputFolder;
 
+	public void setOutputFolder(String outputFolder) {
+		this.outputFolder = outputFolder;
+	}
+
 	/**
 	 * Initials to add to the start of a file name, the rest
 	 * of which is made up from the date. 

--- a/src/whistlesAndMoans/WhistleBinaryDataSource.java
+++ b/src/whistlesAndMoans/WhistleBinaryDataSource.java
@@ -278,7 +278,7 @@ public class WhistleBinaryDataSource extends BinaryDataSource {
 		 *  If we're n network receive mode, we can't do this until 
 		 *  channel numbers have been reassigned.   
 		 */
-		if (runMode == PamController.RUN_PAMVIEW && delays != null) {
+		if ((runMode == PamController.RUN_PAMVIEW || runMode == PamController.RUN_NOTHING) && delays != null) {
 			ShapeConnector shapeConnector = wmDetector.findShapeConnector(channelMap);
 			if (shapeConnector != null) {
 				BearingLocaliser bl = shapeConnector.getBearingLocaliser();


### PR DESCRIPTION
* Fix network sender since it was hopelessly out of date and did not send data in the correct format. OK now, though only tested on NARW.

* Fix network sender since it was hopelessly out of date and did not send data in the correct format. OK now, though only tested on NARW.

* Mods to support command line and Network control of PAMGuard and to retrieve summary information from some modules.

* Fix issue #80: recording path command line override

* Allow RUNNOTHING bearing calculations

Co-authored-by: Douglas Gillespie <50671166+douggillespie@users.noreply.github.com>