### PR TITLE
Fix vector error

### DIFF
--- a/src/pamMaths/PamVector.java
+++ b/src/pamMaths/PamVector.java
@@ -905,7 +905,7 @@ public class PamVector implements Serializable, Cloneable, PamCoordinate, Manage
 		}
 		double[] angs = new double[3];
 		angs[0] = vectors[0].getHeading();
-		angs[1] = vectors[1].getPitch();
+		angs[1] = vectors[0].getPitch();
 		if (vectors.length >= 2) {
 			angs[2] = vectors[1].getPitch();
 		}


### PR DESCRIPTION
Fix error in PamVector getMinimalHeadingPitchRoll function which referenced second element even if there was only one element.